### PR TITLE
Feature/assert xpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and run the `php composer.phar install` command to install it:
 ~~~json
 {
     "require-dev": {
-        "phpunit/phpunit-dom-assertions": "~1.0"
+        "phpunit/phpunit-dom-assertions": "1.0.*@dev"
     }
 }
 ~~~

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ A work in progress, drop-in replacement for the following deprecated PHPUnit ass
  * `assertSelectCount()`
  * `assertSelectRegExp()`
  * `assertSelectEquals()`
+ * `assertXPathCount()`
+ * `assertXPathRegExp()`
+ * `assertXPathEquals()`
  * `assertTag()` (not yet ported)
  * `assertNotTag()` (not yet ported)
 
@@ -14,7 +17,6 @@ A work in progress, drop-in replacement for the following deprecated PHPUnit ass
  * Improve tests.
  * Improve error messages.
  * Improve comments and documentation.
- * Add XPath support.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class DOMTest extends PHPUnit_Framework_DOMTestCase
         $selector = 'span.test_class';
         $content  = 'Test Class Text';
 
-        $this->assertSelectEquals($selector, $content, true, $html);
+        self::assertSelectEquals($selector, $content, true, $html);
     }
 }
 ~~~

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class DOMTest extends PHPUnit_Framework_DOMTestCase
         $selector = 'span.test_class';
         $content  = 'Test Class Text';
 
-        $this->assertSelectEquals($selector, $content, true, html);
+        $this->assertSelectEquals($selector, $content, true, $html);
     }
 }
 ~~~

--- a/src/DOMTestCase.php
+++ b/src/DOMTestCase.php
@@ -252,8 +252,8 @@ abstract class PHPUnit_Framework_DOMTestCase extends PHPUnit_Framework_TestCase
                 return $node->text() === '';
             }
 
-            if (preg_match('/^regexp\s*:\s*(.*)/i', $content, $matches)) {
-                return (bool) preg_match($matches[1], $node->text());
+            if (preg_match('/^regexp\s:*\s*(?P<matchName>.*)/i', $content, $matches)) {
+                return (bool) preg_match($matches['matchName'], $node->text());
             }
 
             return strstr($node->text(), $content) !== false;

--- a/src/DOMTestTrait.php
+++ b/src/DOMTestTrait.php
@@ -107,7 +107,7 @@ trait PHPUnit_Framework_DOMTestTrait
      * @param $message
      * @param $isHtml
      */
-    public static function assertXPathRegExp($selector, $pattern, $count, $actual, $message, $isHtml)
+    public static function assertXPathRegExp($selector, $pattern, $count, $actual, $message = '', $isHtml = true)
     {
         PHPUnit_Framework_DOMTestCase::assertXPathRegExp($selector, $pattern, $count, $actual, $message, $isHtml);
     }
@@ -122,7 +122,7 @@ trait PHPUnit_Framework_DOMTestTrait
      * @param $message
      * @param $isHtml
      */
-    public static function assertXPathEquals($selector, $content, $count, $actual, $message, $isHtml)
+    public static function assertXPathEquals($selector, $content, $count, $actual, $message = '', $isHtml = true)
     {
         PHPUnit_Framework_DOMTestCase::assertXPathEquals($selector, $content, $count, $actual, $message, $isHtml);
     }

--- a/tests/DomTestCaseTest.php
+++ b/tests/DomTestCaseTest.php
@@ -1008,6 +1008,7 @@ class PHPUnit_Framework_DOMTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers            PHPUnit_Framework_DOMTestCase::assertXPathCount
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that false is true.
      */
     public function testAssertXPathCountPresentFalse()
     {
@@ -1031,6 +1032,7 @@ class PHPUnit_Framework_DOMTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers            PHPUnit_Framework_DOMTestCase::assertXPathCount
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that true is false.
      */
     public function testAssertXPathCountNotPresentFalse()
     {
@@ -1065,6 +1067,7 @@ class PHPUnit_Framework_DOMTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers PHPUnit_Framework_DOMTestCase::assertXPathRegExp
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that true is false.
      */
     public function testAssertXPathRegExpContentNotPresentTrue()
     {
@@ -1077,6 +1080,7 @@ class PHPUnit_Framework_DOMTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers PHPUnit_Framework_DOMTestCase::assertXPathRegExp
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that false is true.
      */
     public function testAssertXPathRegExpContentNotPresentFalse()
     {

--- a/tests/XPathTestCaseTest.php
+++ b/tests/XPathTestCaseTest.php
@@ -27,6 +27,7 @@ class PHPUnit_Framework_XPathTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers            PHPUnit_Framework_DOMTestCase::assertXPathCount
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that false is true.
      */
     public function testAssertXPathCountPresentFalse()
     {
@@ -50,6 +51,7 @@ class PHPUnit_Framework_XPathTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers            PHPUnit_Framework_DOMTestCase::assertXPathCount
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that true is false.
      */
     public function testAssertXPathCountNotPresentFalse()
     {
@@ -84,6 +86,7 @@ class PHPUnit_Framework_XPathTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers PHPUnit_Framework_DOMTestCase::assertXPathRegExp
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that true is false.
      */
     public function testAssertXPathRegExpContentNotPresentTrue()
     {
@@ -96,6 +99,7 @@ class PHPUnit_Framework_XPathTestCaseTest extends PHPUnit_Framework_DOMTestCase
     /**
      * @covers PHPUnit_Framework_DOMTestCase::assertXPathRegExp
      * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedExceptionMessage Failed asserting that false is true.
      */
     public function testAssertXPathRegExpContentNotPresentFalse()
     {


### PR DESCRIPTION
Adds asserts for elements using XPath rather than CSS selectors. Works in a similar way to the existing asserts.
