### PR TITLE
[CI] Fix build on --prefer-lowest by restricting real minimum supported versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.1",
         "symfony/css-selector": "^4.4 || ^5.0",
         "symfony/dom-crawler": "^4.4 || ^5.0",
-        "phpunit/phpunit": "^6.4 || ^7.5 || ^8.5 || ^9.0"
+        "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5 || ^9.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "symfony/css-selector": ">=2.4 <6",
-        "symfony/dom-crawler": ">=2.4 <6",
-        "phpunit/phpunit": ">=4.0 <10"
+        "symfony/css-selector": "^4.4 || ^5.0",
+        "symfony/dom-crawler": "^4.4 || ^5.0",
+        "phpunit/phpunit": "^6.4 || ^7.5 || ^8.5 || ^9.0"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,6 @@
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,6 @@
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=0"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 </phpunit>


### PR DESCRIPTION
As shown in https://github.com/lstrojny/phpunit-dom-assertions/runs/1708146922, we never tested with `--prefer-lowest`, so constraints like `"symfony/dom-crawler": ">=2.4"` where somehow a lie.

The proposed constraints are the minimum required to get the build passing